### PR TITLE
Add more unit tests along with describe statements

### DIFF
--- a/test/unit/ourToken-unit.test.js
+++ b/test/unit/ourToken-unit.test.js
@@ -3,7 +3,8 @@ const { getNamedAccounts, deployments, ethers } = require("hardhat");
 const { INITIAL_SUPPLY } = require("../../helper-hardhat-config");
 
 describe("OurToken Unit Test", function () {
-
+    //Multipler is used to make reading the math easier because of the 18 decimal points
+    const multiplier = 10 ** 18;
     let ourToken, deployer, user1;
     beforeEach(async function () {
         const accounts = await getNamedAccounts();
@@ -13,23 +14,85 @@ describe("OurToken Unit Test", function () {
         await deployments.fixture("all");
         ourToken = await ethers.getContract("OurToken", deployer);
     });
-   
-    it("Should have correct INITIAL_SUPPLY of token ", async function () {
-        const totalSupply = await ourToken.totalSupply();
-        assert.equal(totalSupply.toString(), INITIAL_SUPPLY);
-    }); 
-
-    it("Should be able to transfer tokens successfully to an address", async function () {
-        const tokensToSend = ethers.utils.parseEther("10");
-        await ourToken.transfer(user1,tokensToSend);
-        expect(await ourToken.balanceOf(user1)).to.equal(tokensToSend);
+    it("was deployed", async () => {
+        assert(ourToken.address);
     });
+    describe("constructor", () => {
+        it("Should have correct INITIAL_SUPPLY of token ", async () => {
+            const totalSupply = await ourToken.totalSupply();
+            assert.equal(totalSupply.toString(), INITIAL_SUPPLY);
+        });
+        it("initializes the token with the correct name and symbol ", async () => {
+            const name = (await ourToken.name()).toString();
+            assert.equal(name, "OurToken");
 
-    it("Should approve other address to spend token", async () => {
-        const tokensToSpend = ethers.utils.parseEther("5");
-        await ourToken.approve(user1, tokensToSpend);
-        const ourToken1 = await ethers.getContract("OurToken", user1);
-        await ourToken1.transferFrom(deployer,user1,tokensToSpend);
-        expect(await ourToken1.balanceOf(user1)).to.equal(tokensToSpend);
+            const symbol = (await ourToken.symbol()).toString();
+            assert.equal(symbol, "OT");
+        });
+    });
+    describe("minting", () => {
+        it("user can not mint", async () => {
+            try {
+                await ourToken._mint(deployer, 100);
+                assert(false);
+            } catch (e) {
+                assert(e);
+            }
+        });
+    });
+    describe("transfers", () => {
+        it("Should be able to transfer tokens successfully to an address", async () => {
+            const tokensToSend = ethers.utils.parseEther("10");
+            await ourToken.transfer(user1, tokensToSend);
+            expect(await ourToken.balanceOf(user1)).to.equal(tokensToSend);
+        });
+        it("emits an transfer event, when an transfer occurs", async () => {
+            await expect(
+                ourToken.transfer(user1, (10 * multiplier).toString())
+            ).to.emit(ourToken, "Transfer");
+        });
+        describe("allowances", () => {
+            const amount = (20 * multiplier).toString();
+            beforeEach(async () => {
+                playerToken = await ethers.getContract("OurToken", user1);
+            });
+            it("Should approve other address to spend token", async () => {
+                const tokensToSpend = ethers.utils.parseEther("5");
+                await ourToken.approve(user1, tokensToSpend);
+                const ourToken1 = await ethers.getContract("OurToken", user1);
+                await ourToken1.transferFrom(deployer, user1, tokensToSpend);
+                expect(await ourToken1.balanceOf(user1)).to.equal(
+                    tokensToSpend
+                );
+            });
+            it("doesn't allow an unnaproved member to do transfers", async () => {
+                //Deployer is approving that user1 can spend 20 of their precious OT's
+
+                await expect(
+                    playerToken.transferFrom(deployer, user1, amount)
+                ).to.be.revertedWith("ERC20: insufficient allowance");
+            });
+            it("emits an approval event, when an approval occurs", async () => {
+                await expect(ourToken.approve(user1, amount)).to.emit(
+                    ourToken,
+                    "Approval"
+                );
+            });
+            it("the allowance being set is accurate", async () => {
+                await ourToken.approve(user1, amount);
+                const allowance = await ourToken.allowance(deployer, user1);
+                assert.equal(allowance.toString(), amount);
+            });
+            it("won't allow a user to go over the allowance", async () => {
+                await ourToken.approve(user1, amount);
+                await expect(
+                    playerToken.transferFrom(
+                        deployer,
+                        user1,
+                        (40 * multiplier).toString()
+                    )
+                ).to.be.revertedWith("ERC20: insufficient allowance");
+            });
+        });
     });
 });


### PR DESCRIPTION
This request includes the addition of more unit tests that explore more of the functionality of the erc20 token contract including the events that are emitted and different error messages. It also includes the addition of describe statements, which better organize the information within the tests. This makes it easier for people that are using the course to follow along with the tests in the GitHub because they will have a better understanding of what each section is for. It also more closely follows the manner in which testing was done in the course.