### PR TITLE
Update hardhat.config REPORT_GAS

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -29,7 +29,7 @@ const ETHERSCAN_API_KEY =
   process.env.ETHERSCAN_API_KEY || "Your etherscan API key"
 const POLYGONSCAN_API_KEY =
   process.env.POLYGONSCAN_API_KEY || "Your polygonscan API key"
-const REPORT_GAS = process.env.REPORT_GAS || false
+const REPORT_GAS = process.env.REPORT_GAS.toLowerCase() === "true" || false
 
 module.exports = {
   defaultNetwork: "hardhat",


### PR DESCRIPTION
If we set `REPORT_GAS` as `process.env.REPORT_GAS`, in case we have it defined in our `.env` we will always get `true` value from it no matter what it says. To see this we have to parse it to boolean and simply print it by `consolge.log`. We can fix this to work properly adding my code, so our `.env` can work good with "true" or "false" statements. Otherwise this `REPORT_GAS` will always create gas-report.txt if it is defined in .env